### PR TITLE
Fix Catch2 include dir

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -27,7 +27,7 @@ add_custom_target(external-Catch-update
     COMMAND ${GIT_EXECUTABLE} pull
     DEPENDS Catch)
 # set include directory
-set(EXTERNAL_CATCH_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Catch/src/Catch/single_include" PARENT_SCOPE)
+set(EXTERNAL_CATCH_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Catch/src/Catch/single_include/Catch2" PARENT_SCOPE)
 
 
 # Examples for External Projects


### PR DESCRIPTION
I am getting an error when trying to run the `check` command:

```
ninja check
[8/12] Linking CXX executable source/exampleApp.app/Contents/MacOS/exampleApp
ld: warning: URGENT: building for OSX, but linking against dylib (/usr/lib/libc++.dylib) built for (unknown). Note: This will be an error in the future.
ld: warning: URGENT: building for OSX, but linking against dylib (/usr/lib/libSystem.dylib) built for (unknown). Note: This will be an error in the future.
[9/12] Building CXX object source/unittest/CMakeFiles/unittests.dir/testmain.cpp.o
FAILED: source/unittest/CMakeFiles/unittests.dir/testmain.cpp.o
/usr/local/Cellar/ccache/3.5/libexec/c++  -DUNIT_TESTS -I../source/unittest/.. -isystem ../external/Catch/src/Catch/single_include -std=c++14 -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wunused -pedantic -MD -MT source/unittest/CMakeFile
s/unittests.dir/testmain.cpp.o -MF source/unittest/CMakeFiles/unittests.dir/testmain.cpp.o.d -o source/unittest/CMakeFiles/unittests.dir/testmain.cpp.o -c ../source/unittest/testmain.cpp
../source/unittest/testmain.cpp:3:10: fatal error: 'catch.hpp' file not found
#include "catch.hpp"
         ^~~~~~~~~~~
1 error generated.
[10/12] Building CXX object source/unittest/CMakeFiles/unittests.dir/__/SomeClass.cpp.o
FAILED: source/unittest/CMakeFiles/unittests.dir/__/SomeClass.cpp.o
/usr/local/Cellar/ccache/3.5/libexec/c++  -DUNIT_TESTS -I../source/unittest/.. -isystem ../external/Catch/src/Catch/single_include -std=c++14 -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wunused -pedantic -MD -MT source/unittest/CMakeFile
s/unittests.dir/__/SomeClass.cpp.o -MF source/unittest/CMakeFiles/unittests.dir/__/SomeClass.cpp.o.d -o source/unittest/CMakeFiles/unittests.dir/__/SomeClass.cpp.o -c ../source/SomeClass.cpp
../source/SomeClass.cpp:20:10: fatal error: 'catch.hpp' file not found
#include "catch.hpp"
         ^~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```

Hence, we either need to fix the Catch2 include dir or use `#include "Catch2/catch.hpp"`. I decided to do the former for simplicity.