### PR TITLE
Fix Catch2 include dir v2: case sensitive folder

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -27,7 +27,7 @@ add_custom_target(external-Catch-update
     COMMAND ${GIT_EXECUTABLE} pull
     DEPENDS Catch)
 # set include directory
-set(EXTERNAL_CATCH_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Catch/src/Catch/single_include/Catch2" PARENT_SCOPE)
+set(EXTERNAL_CATCH_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Catch/src/Catch/single_include/catch2" PARENT_SCOPE)
 
 
 # Examples for External Projects


### PR DESCRIPTION
Apologies, but I did not use the proper case sensitive folder name in previous PR and it broke CI since it uses Linux: https://travis-ci.org/kracejic/cleanCppProject

This one does work. I promise ;)
- https://travis-ci.org/kracejic/cleanCppProject/builds/445576883
- https://travis-ci.org/pamarcos/cleanCppProject/builds/445575266