### PR TITLE
add usage of run-cmake action for CI

### DIFF
--- a/.github/workflows/github-ci-run-cmake.yml
+++ b/.github/workflows/github-ci-run-cmake.yml
@@ -1,0 +1,33 @@
+name: CI-build-and-test
+
+on: 
+  push:
+    # To run on all branches, but not 'master'.
+    branches:
+      -  '*'
+      - '!master'
+  pull_request:
+jobs:
+  build:
+    name: CI-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: build and test
+      uses: lukka/run-cmake@v0
+      with:
+        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+        cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+        buildDirectory: '${{ runner.workspace }}/build'
+        cmakeAppendedArgs: '-G "Ninja"'
+        buildWithCMakeArgs: "--target check -- -j 0"
+    - name: archive build output
+      uses: actions/upload-artifact@v1
+      with:
+        name: packages
+        path: ${{ runner.workspace }}/build/source/


### PR DESCRIPTION
Hello,
here there is a modified version of the CI build, in detail:
- the workflow execute build and test for the major platforms: linux, macos, windows;
- the workflow only builds and test, it does not package nor install on the build server; on CI it should not be needed to package and install the package (especially if the package is not automatically tested anyway). Also this make the CI shorter in time; it would make sense to package the product in build on push on `master` branch though.
- the workflow uses a specific [run-cmake](https://github.com/marketplace/actions/run-cmake) action to configure and build in one step; the run-cmake action provision automatically 'ninja' if not present and it integrates with vcpkg (if used) using the [run-vcpkg](https://github.com/marketplace/actions/run-vcpkg) action;

There might be several reasons that would block this PR or that request heavy changes: I am fine with this of course! 
